### PR TITLE
GSL: fix of header inclusion in C++ code

### DIFF
--- a/tracy/src/Makefile.am
+++ b/tracy/src/Makefile.am
@@ -25,7 +25,8 @@ AM_CPPFLAGS = -I../inc \
               $(GSL_CFLAGS)
 
 # C++ flags.
-AM_CXXFLAGS = -g -O0 -Wall -Wno-error=all -std=gnu++11 -fPIC
+AM_CXXFLAGS = -g -O0 -Wall -Wno-error=all -std=gnu++11 -fPIC \
+              $(GSL_CFLAGS)
 
 # Fortan flags.
 FFLAGS      = -g -O2 -Wall -fbounds-check -fdefault-integer-8 -mcmodel=large


### PR DESCRIPTION
GSL is used by c++ code too. Thus it needs to be able to find
the GSL headers too. This should fix GSL compile issues if
GSL headers are not found in standard location