### PR TITLE
Handling get_eps_x: handling return vectors: First step 

### DIFF
--- a/python/src/tracy_py.cc
+++ b/python/src/tracy_py.cc
@@ -1,7 +1,8 @@
 #include <pybind11/stl.h>
 #include <pybind11/pybind11.h>
 // #include <pybind11/operators.h>
-#include <pybind11/numpy.h>
+#include <vector>
+#include <tuple>
 
 #include "tracy_lib.h"
 
@@ -21,7 +22,7 @@ void declare_field(py::module &scsi, const std::string &typestr) {
     .def("__repr__", [](const ss_vect<T> &a) {
 		       std::stringstream stream;
 		       stream << a;
-		       return stream.str(); 
+		       return stream.str();
 		     })
     .def("print",      &Class::print)
     .def("__getitem__", [](const ss_vect<T> &a, const int k) {
@@ -33,6 +34,28 @@ void declare_field(py::module &scsi, const std::string &typestr) {
     .def("zero",       &Class::zero)
     .def("identity",   &Class::identity);
 }
+
+
+/*
+ * get_eps_x: provide the memory and return it to python
+ *            TODO: check for memory leaks!
+ */
+class LatticeTypePy : public LatticeType {
+
+public:
+    std::tuple<double, double, double, std::vector<double>,std::vector<double>,std::vector<double>>
+    get_eps_x_py(const bool prt){
+		double eps_x, sigma_delta, U_0;
+		// TODO: allocate appropriate space
+		std::vector<double> J(3, 0.0), tau(3, 0.0), I(3, 0.0);
+
+		get_eps_x(eps_x, sigma_delta, U_0, J, tau, I, prt);
+
+		std::tuple<double, double, double, std::vector<double>,std::vector<double>,std::vector<double>>
+		  tup( make_tuple(eps_x, sigma_delta, U_0, J, tau, I));
+		return tup;
+	}
+};
 
 
 PYBIND11_MODULE(libtracy, scsi) {
@@ -235,35 +258,35 @@ PYBIND11_MODULE(libtracy, scsi) {
       .def_readwrite("DBNlist", &ElemFamType::DBNlist)
       .def(py::init<>());
 
-    py::class_<LatticeType>(scsi, "LatticeType")
+    py::class_<LatticeTypePy>(scsi, "LatticeType")
       // std::vector<ElemFamType>
-      .def_readwrite("elemf", &LatticeType::elemf)
+      .def_readwrite("elemf", &LatticeTypePy::elemf)
       // std::vector<ElemType*>
-      .def_readwrite("elems", &LatticeType::elems)
+      .def_readwrite("elems", &LatticeTypePy::elems)
       // ConfigType
-      .def_readwrite("conf",  &LatticeType::conf)
+      .def_readwrite("conf",  &LatticeTypePy::conf)
       .def(py::init<>())
-      .def("Lat_Init",      &LatticeType::Lat_Init)
-      .def("prt_fams",      &LatticeType::prt_fams)
-      .def("prt_elems",     &LatticeType::prt_elems)
-      .def("GetnKid",       &LatticeType::GetnKid)
-      .def("ElemIndex",     &LatticeType::ElemIndex)
-      .def("Elem_GetPos",   &LatticeType::Elem_GetPos)
-      .def("Lat_Read",      &LatticeType::Lat_Read)
-      .def("prtmfile",      &LatticeType::prtmfile)
-      .def("rdmfile",       &LatticeType::rdmfile)
-      .def("prt_lat1",      &LatticeType::prt_lat1)
-      .def("prt_lat2",      &LatticeType::prt_lat2)
-      .def("prt_lat3",      &LatticeType::prt_lat3)
-      .def("prt_lat4",      &LatticeType::prt_lat4)
-      .def("getcod",        &LatticeType::getcod)
-      .def("Ring_GetTwiss", &LatticeType::Ring_GetTwiss)
-      .def("ChamberOff",    &LatticeType::ChamberOff)
-      .def("print",         &LatticeType::print)
-      .def("get_eps_x",     &LatticeType::get_eps_x)
-      .def("GetEmittance",  &LatticeType::GetEmittance)
-      .def("Cell_Pass1",    &LatticeType::Cell_Pass1)
-      .def("Cell_Pass2",    &LatticeType::Cell_Pass2);
+      .def("Lat_Init",      &LatticeTypePy::Lat_Init)
+      .def("prt_fams",      &LatticeTypePy::prt_fams)
+      .def("prt_elems",     &LatticeTypePy::prt_elems)
+      .def("GetnKid",       &LatticeTypePy::GetnKid)
+      .def("ElemIndex",     &LatticeTypePy::ElemIndex)
+      .def("Elem_GetPos",   &LatticeTypePy::Elem_GetPos)
+      .def("Lat_Read",      &LatticeTypePy::Lat_Read)
+      .def("prtmfile",      &LatticeTypePy::prtmfile)
+      .def("rdmfile",       &LatticeTypePy::rdmfile)
+      .def("prt_lat1",      &LatticeTypePy::prt_lat1)
+      .def("prt_lat2",      &LatticeTypePy::prt_lat2)
+      .def("prt_lat3",      &LatticeTypePy::prt_lat3)
+      .def("prt_lat4",      &LatticeTypePy::prt_lat4)
+      .def("getcod",        &LatticeTypePy::getcod)
+      .def("Ring_GetTwiss", &LatticeTypePy::Ring_GetTwiss)
+      .def("ChamberOff",    &LatticeTypePy::ChamberOff)
+      .def("print",         &LatticeTypePy::print)
+      .def("get_eps_x",     &LatticeTypePy::get_eps_x_py)
+      .def("GetEmittance",  &LatticeTypePy::GetEmittance)
+      .def("Cell_Pass1",    &LatticeTypePy::Cell_Pass1)
+      .def("Cell_Pass2",    &LatticeTypePy::Cell_Pass2);
 
     py::class_<DriftType, ElemType>(scsi, "DriftType")
       .def(py::init<>());

--- a/python/tests/lattice_test.py
+++ b/python/tests/lattice_test.py
@@ -1,7 +1,7 @@
 import os, sys
 
-tracy_dir = os.getenv('TRACY_LIB')
-sys.path.append(tracy_dir+'/tracy/lib')
+# tracy_dir = os.getenv('TRACY_LIB')
+# sys.path.append(tracy_dir+'/tracy/lib')
 
 import unittest
 import libtracy as scsi
@@ -33,19 +33,28 @@ class _LatticeBasicFunctionality(unittest.TestCase):
 
         self.lat = lat
 
-    @unittest.skip
+    # @unittest.skip
     def test0_readFile(self):
         '''Test if reading file from path works
         '''
         self.lat.Lat_Read(self.lattice_filename)
 
-    @unittest.skip
-    def test0_readInit(self):
+    # @unittest.skip
+    def test1_readInit(self):
         '''Test if reading file and init works
         '''
         lat = self.lat
         lat.Lat_Read(self.lattice_filename)
         lat.Lat_Init()
+
+    def test2_eps_get_x(self):
+        '''Test emmittance computation test
+        '''
+        lat = self.lat
+        lat.Lat_Read(self.lattice_filename)
+        lat.Lat_Init()
+        ret = lat.get_eps_x(True)
+        eps_x, sigma_delta, U_0, J, tau, I = ret
 
 
 class LatticeBasicFunctionality(_LatticeBasicFunctionality):


### PR DESCRIPTION
Handling  get_eps_x:  return tuple of vectors: possiblemem. leak?
-----------------------------------------------------------------

Outlook
~~~~~
This patch implements the wrapper for geteps_x. It is not fully tested yet as a 
test lattice has to be created. Current evalulations stop on an internal singular
matrix.



Git merge info
~~~~~~~~~

geteps_x puts in into some vectors. This requires allocation of these
arrays. Handled by an overloaded class.

Warning:
     check for memory leak not yet madeo
     Test not yet checked as proper test lattice needs to
     be defined