### PR TITLE
python interface: check that NO_TPSA is defined

### DIFF
--- a/python/src/tracy_py.cc
+++ b/python/src/tracy_py.cc
@@ -9,6 +9,14 @@
 namespace py = pybind11;
 
 
+#ifndef NO_TPSA
+#error "NO_TPSA not defined: code most probably will not work"
+#endif
+
+#if NO_TPSA != 1
+#warning "NO TPSA is expected to be defined as 1. "
+#endif /* NO_TPSA != 1 */
+
 // Polymorphic number template class wrapper.
 
 template<typename T>


### PR DESCRIPTION
This commit follows work in progress.

Items to discuss
-----------------
Review naming of main  python module. Shall it be **`tracy`** or **`scsi`?**


Code base clean up
--------------------
python/ directory cleaned up

- created separate module directory for tracy called `tracy`
- c++ extension module now called ``lib`. So import now is 
   ```python
   import tracy.lib
   ```
- Modules I considered utils are moved to utils
- Examples are now in examples
 
Todo
-----
Fix memory handling of extension module
