### PR TITLE
rdmfile_at.cc: Implement IdTablePass and IdTableRadPass

### DIFF
--- a/tracy/src/nsls-ii_lib.cc
+++ b/tracy/src/nsls-ii_lib.cc
@@ -539,12 +539,28 @@ void GetEmittance(const int Fnum_cav, const bool path_length, const bool prt)
   // radiation loss is computed in Cav_Pass
 
   globval.U0 = globval.dE*1e9*globval.Energy;
-  V_RF = Cell[Elem_GetPos(Fnum_cav, 1)].Elem.C->V_RF;
+
+  // For lattices with multiple RF cavities, use the
+  // total RF voltage seen per turn for synchronous phase / bucket height.
+  V_RF = 0e0;
   h_RF = Cell[Elem_GetPos(Fnum_cav, 1)].Elem.C->harm_num;
-  phi0 = fabs(asin(globval.U0/V_RF));
-  globval.delta_RF =
-    sqrt(-V_RF*cos(M_PI-phi0)*(2.0-(M_PI-2.0*(M_PI-phi0))
-    *tan(M_PI-phi0))/(fabs(globval.Alphac)*M_PI*h_RF*1e9*globval.Energy));
+  for (j = 1; j <= ElemFam[Fnum_cav-1].nKid; j++)
+    V_RF += Cell[Elem_GetPos(Fnum_cav, j)].Elem.C->V_RF;
+
+  {
+    const double arg = globval.U0/V_RF;
+    if (fabs(arg) <= 1e0) {
+      phi0 = fabs(asin(arg));
+      globval.delta_RF =
+        sqrt(-V_RF*cos(M_PI-phi0)*(2.0-(M_PI-2.0*(M_PI-phi0))
+        *tan(M_PI-phi0))/(fabs(globval.Alphac)*M_PI*h_RF*1e9*globval.Energy));
+    } else { // Print error if RF voltage is insufficient to compensate for radiation loss.
+      printf("GetEmittance: insufficient RF voltage: |U0/V_RF| = %.6f > 1 with V_RF = %.6f, U0 = %.6f\n",
+             fabs(arg), V_RF, globval.U0);
+      phi0 = NAN;
+      globval.delta_RF = NAN;
+    }
+  }
 
   // Compute diffusion coeffs. for eigenvectors [sigma_xx, sigma_yy, sigma_zz]
   Ascr_map = putlinmat(6, globval.Ascr);

--- a/tracy/src/param.cc
+++ b/tracy/src/param.cc
@@ -685,6 +685,11 @@ void param_data_type::get_param(const string &param_file)
         sstr.clear(); sstr.str("");
 	sstr << in_dir << str; lat_FileName = sstr.str();
         Read_Lattice(lat_FileName.c_str());
+      } else if (strcmp("at_flat_file", name) == 0) {
+	sscanf(line, "%*s %s", str);
+	sstr.clear(); sstr.str("");
+	sstr << str << "flat_file.dat"; flat_file = sstr.str();
+	rdmfile_at(flat_file.c_str());
       } else if (strcmp("flat_file", name) == 0) {
 	sscanf(line, "%*s %s", str);
 	sstr.clear(); sstr.str("");

--- a/tracy/src/rdmfile_at.cc
+++ b/tracy/src/rdmfile_at.cc
@@ -361,6 +361,8 @@ static void create_elem(Element &curr_elem)
     auto E_0 = curr_elem.props.find("Energy")->second.at(0).number;
 
     globval.Energy = 1e-9*E_0;
+    elem.C->V_RF   = V_RF;   // [V]
+    elem.C->f_RF   = f_RF;   // [Hz]
 
     if (dbg) {
       printf("  V_RF       = %9.3e\n", V_RF);

--- a/tracy/src/rdmfile_at.cc
+++ b/tracy/src/rdmfile_at.cc
@@ -28,9 +28,16 @@ static const bool dbg = false;
 
 void string_to_c_str(const std::string &str, partsName &c_str) {
   // Tracy-2 element names are not "\0" terminated C strings (Pascal legacy).
+  // Keep symbol names in the same canonical format used by ElemIndex:
+  // lowercase pad with spaces up to SymbolLength.
   if (str.size() > NameLength)
     throw std::runtime_error("ElemName too long for fixed buffer");
-  memcpy(c_str, str.data(), str.size());
+
+  memset(c_str, 0, sizeof(partsName));
+  for (size_t i = 0; i < str.size(); i++)
+    c_str[i] = (char)std::tolower((unsigned char)str[i]);
+  for (size_t i = str.size(); i < SymbolLength; i++)
+    c_str[i] = ' ';
 }
 
 struct Value {
@@ -218,6 +225,42 @@ static void print_elem(Element &elem) {
       print_value(kv.second[i]);
     }
     std::cout << "\n";
+  }
+}
+
+// Post-processing pass: assign Fnum/Knum/ElemFam from element names, matching
+// Elements sharing the same PName belong to the same family.
+static void assign_elem_families()
+{
+  std::unordered_map<std::string, int> name_to_fnum;
+  globval.Elem_nFam = 0;
+
+  for (long i = 0; i <= globval.Cell_nLoc; i++) {
+    CellType &cell = Cell[i];
+    std::string name(cell.Elem.PName);
+
+    auto result = name_to_fnum.emplace(name, (int)globval.Elem_nFam + 1);
+    const bool inserted = result.second;
+    const int  fnum     = result.first->second;
+
+    if (inserted) {
+      // First kid of this family: initialise the family prototype.
+      globval.Elem_nFam++;
+      memset(ElemFam[fnum-1].ElemF.PName, 0, sizeof(partsName));
+      memcpy(ElemFam[fnum-1].ElemF.PName, cell.Elem.PName,
+             sizeof(partsName));
+      ElemFam[fnum-1].nKid = 0;
+    }
+
+    cell.Fnum = fnum;
+    ElemFam[fnum-1].nKid++;
+    cell.Knum = ElemFam[fnum-1].nKid;
+
+    // KidList and ElemF.Pkind are only populated for i > 0, exclude ring-origin marker.
+    if (i > 0) {
+      ElemFam[fnum-1].KidList[cell.Knum - 1] = i;
+      ElemFam[fnum-1].ElemF.Pkind = cell.Elem.Pkind;
+    }
   }
 }
 
@@ -585,4 +628,14 @@ void rdmfile_at(const std::string& file_name) {
 
   printf("\nrdmfile_at: read %ld elements, C = %7.5f\n",
 	 globval.Cell_nLoc+1, Cell[globval.Cell_nLoc].S);
+
+  assign_elem_families();
+
+  // Compute harmonic number for all cavity elements now that C is known.
+  const double C_ring = Cell[globval.Cell_nLoc].S;
+  for (long i = 0; i <= globval.Cell_nLoc; i++) {
+    if (Cell[i].Elem.Pkind == PartsKind(Cavity) && Cell[i].Elem.C->f_RF != 0.0)
+      Cell[i].Elem.C->harm_num =
+        (int)std::round(Cell[i].Elem.C->f_RF * C_ring / c0);
+  }
 }

--- a/tracy/src/rdmfile_at.cc
+++ b/tracy/src/rdmfile_at.cc
@@ -13,7 +13,8 @@
     * CorrectorPass
     * DriftPass
     * EAperturePass
-    IdTablePass
+    * IdTablePass
+    * IdTableRadPass
     * IdentityPass
     * RFCavityPass
     * StrMPoleSymplectic4Pass
@@ -145,7 +146,60 @@ parse_property_line(std::string line) {
   return {key, std::move(values)};
 }
 
-static void print_value(const Value& v) {
+// Parse property lines that represent tables where ';' is a value/row separator.
+// Handles: xtable/ytable (1D) and xkick/ykick/xkick1/ykick1/B2 (2D, rows by ';', cols by ',').
+// Values are flattened into a single vector.
+static std::pair<std::string, std::vector<Value>>
+parse_table_line(std::string line) {
+  line = trim(line);
+  if (line.empty())
+    throw std::runtime_error("Empty property line");
+
+  // Strip trailing ';' if present.
+  if (line.back() == ';') {
+    line.pop_back();
+    line = trim(line);
+  }
+
+  // Key is everything before the first ','.
+  auto comma_pos = line.find(',');
+  if (comma_pos == std::string::npos)
+    throw std::runtime_error("Property line missing key separator: " + line);
+
+  std::string key = trim(line.substr(0, comma_pos));
+  std::string rest = line.substr(comma_pos + 1);
+
+  // Split by ';' into segments, then each segment by ',' into values.
+  std::vector<Value> values;
+  std::vector<std::string> segments;
+  std::string cur;
+  for (char c : rest) {
+    if (c == ';') {
+      segments.push_back(cur);
+      cur.clear();
+    } else
+      cur.push_back(c);
+  }
+  if (!trim(cur).empty())
+    segments.push_back(cur);
+
+  for (const auto &seg : segments) {
+    auto tokens = split_csv_like(seg);
+    for (const auto &tok : tokens) {
+      std::string t = trim(tok);
+      if (t.empty())
+        continue;
+      double d = 0.0;
+      if (!try_parse_double(t, d))
+        throw std::runtime_error("Non-numeric value in " + key + ": " + t);
+      values.push_back(Value::Num(d));
+    }
+  }
+
+  return {key, std::move(values)};
+}
+
+static void print_value(const Value &v) {
   if (v.isNumber) std::cout << v.number;
   else std::cout << v.text;
 }
@@ -196,8 +250,8 @@ static void create_elem(Element &curr_elem)
     elem.Pkind = PartsKind(drift);
     Drift_Alloc(&elem);
   } else if ((curr_elem.passMethod == "CorrectorPass") ||
-	     (curr_elem.passMethod == "StrMPoleSymplectic4Pass") ||
-	     (curr_elem.passMethod == "BndMPoleSymplectic4RadPass")) {
+             (curr_elem.passMethod == "StrMPoleSymplectic4Pass") ||
+             (curr_elem.passMethod == "BndMPoleSymplectic4RadPass")) {
     elem.Pkind = PartsKind(Mpole);
     // Multipole.
     Mpole_Alloc(&elem);
@@ -205,12 +259,16 @@ static void create_elem(Element &curr_elem)
     // RF Cavity.
     elem.Pkind = PartsKind(Cavity);
     Cav_Alloc(&elem);
+  } else if (curr_elem.passMethod == "IdTablePass" ||
+             curr_elem.passMethod == "IdTableRadPass") {
+    // Insertion Device (kick map).
+    elem.Pkind = PartsKind(Insertion);
+    Insertion_Alloc(&elem);
   } else if (curr_elem.passMethod == "GWigSymplecticPass") {
     // GWigSymplecticPass    - analytic,
-    // GWigSymplecticRadPass - analytic,
-    // IdTablePass           - kick map.
+    // GWigSymplecticRadPass - analytic.
     std::cout << "create_elem: *** undef. passMethod not implemented - "
-	      << curr_elem.passMethod << "\n";
+              << curr_elem.passMethod << "\n";
     exit(1);
   } else {
     std::cout << "create_elem: *** undef. passMethod - "
@@ -259,24 +317,24 @@ static void create_elem(Element &curr_elem)
       elem.M->Pthick = pthicktype(thick);
     if ((curr_elem.passMethod == "BndMPoleSymplectic4RadPass")
 	&& (elem.M->Pthick == thick)){
-          auto phi = curr_elem.props.find("BendingAngle")->second.at(0).number;
+      auto phi = curr_elem.props.find("BendingAngle")->second.at(0).number;
 	  elem.M->Pirho = phi/elem.PL;
-	  if (dbg)
+      if (dbg)
 	    printf("  phi        = %10.3e\n", phi*180e0/M_PI);
           auto phi_1 =
 	    curr_elem.props.find("EntranceAngle")->second.at(0).number;
-	  elem.M->PTx1 = phi_1;
-	  if (dbg)
+      elem.M->PTx1 = phi_1;
+      if (dbg)
 	    printf("  phi_1      = %10.3e\n", phi_1*180e0/M_PI);
-          auto phi_2 = curr_elem.props.find("ExitAngle")->second.at(0).number;
-	  elem.M->PTx2 = phi_2;
-	  if (dbg)
+      auto phi_2 = curr_elem.props.find("ExitAngle")->second.at(0).number;
+      elem.M->PTx2 = phi_2;
+      if (dbg)
 	    printf("  phi_2      = %10.3e\n", phi_2*180e0/M_PI);
     }
     auto n_int =
       (int)std::round(curr_elem.props.find("NumIntSteps")->second.at(0).number);
     auto max_order =
-      (int)std::round(curr_elem.props.find("MaxOrder")->second.at(0).number);
+        (int)std::round(curr_elem.props.find("MaxOrder")->second.at(0).number);
     elem.M->PN = n_int;
     elem.M->Porder = max_order + 1;
     if (dbg) {
@@ -301,7 +359,7 @@ static void create_elem(Element &curr_elem)
     auto V_RF = curr_elem.props.find("Voltage")->second.at(0).number;
     auto f_RF = curr_elem.props.find("Frequency")->second.at(0).number;
     auto E_0 = curr_elem.props.find("Energy")->second.at(0).number;
-    
+
     globval.Energy = 1e-9*E_0;
 
     if (dbg) {
@@ -310,16 +368,102 @@ static void create_elem(Element &curr_elem)
       printf("  E_0        = %9.3e\n", E_0);
     }
   }
+
+  if (curr_elem.passMethod == "IdTablePass" ||
+      curr_elem.passMethod == "IdTableRadPass") {
+    InsertionType *ID = elem.ID;
+
+    const auto &xtab = curr_elem.props.find("xtable")->second;
+    const auto &ytab = curr_elem.props.find("ytable")->second;
+    const int nx = (int)xtab.size();
+    const int nz = (int)ytab.size();
+
+    if (nx > IDXMAX || nz > IDZMAX) {
+      printf("create_elem: ID table too large:"
+             " nx=%d (max %d), nz=%d (max %d)\n",
+             nx, IDXMAX, nz, IDZMAX);
+      exit(1);
+    }
+
+    ID->nx = nx;
+    ID->nz = nz;
+    for (int j = 0; j < nx; j++)
+      ID->tabx[j] = xtab[j].number;
+    // LinearInterpolation2 expects tabz in decreasing order; AT ytable is
+    // increasing, so reverse it.
+    for (int i = 0; i < nz; i++)
+      ID->tabz[i] = ytab[nz - 1 - i].number;
+
+    // Energy must be set before kick/B2 normalization.
+    auto it_e = curr_elem.props.find("Energy");
+    if (it_e != curr_elem.props.end())
+      globval.Energy = 1e-9 * it_e->second.at(0).number;
+    const double Brho = globval.Energy * 1e9 / c0;
+
+    // Second order kick maps (always present).
+    // The AT flat file stores kicks already divided by Brho^2, but Tracy's
+    // Insertion_Pass applies its own 1/Brho^2 scaling at tracking time.
+    // Multiply by Brho^2 here to recover the raw (T^2 m^2) values.
+    const double Brho2 = Brho * Brho;
+    const auto &xk = curr_elem.props.find("xkick")->second;
+    const auto &yk = curr_elem.props.find("ykick")->second;
+    for (int i = 0; i < nz; i++)
+      for (int j = 0; j < nx; j++) {
+        ID->thetax[i][j] = xk[(nz - 1 - i) * nx + j].number * Brho2;
+        ID->thetaz[i][j] = yk[(nz - 1 - i) * nx + j].number * Brho2;
+      }
+    ID->secondorder = true;
+
+    // First order kick maps (optional).
+    auto it_xk1 = curr_elem.props.find("xkick1");
+    auto it_yk1 = curr_elem.props.find("ykick1");
+    if (it_xk1 != curr_elem.props.end() && it_yk1 != curr_elem.props.end() &&
+        !it_xk1->second.empty() && !it_yk1->second.empty()) {
+      const auto &xk1 = it_xk1->second;
+      const auto &yk1 = it_yk1->second;
+      for (int i = 0; i < nz; i++)
+        for (int j = 0; j < nx; j++) {
+          ID->thetax1[i][j] = xk1[(nz - 1 - i) * nx + j].number;
+          ID->thetaz1[i][j] = yk1[(nz - 1 - i) * nx + j].number;
+        }
+      ID->firstorder = true;
+    } else
+      ID->firstorder = false;
+
+    ID->Pmethod = Meth_First;
+    ID->PN = curr_elem.props.find("Nslice")->second.at(0).number;
+    ID->linear = true;
+    ID->scaling = 1.0;
+
+    // B2 field map (optional, for radiation via IdTableRadPass).
+    // Expected in the same units as Tracy's radiate_ID, i.e. already
+    // normalized by L*Brho^2.  Store as-is.
+    auto it_b2 = curr_elem.props.find("B2");
+    if (it_b2 != curr_elem.props.end() && !it_b2->second.empty()) {
+      const auto &b2 = it_b2->second;
+      for (int i = 0; i < nz; i++)
+        for (int j = 0; j < nx; j++) {
+          ID->B2[i][j] = b2[(nz - 1 - i) * nx + j].number;
+        }
+      ID->long_comp = true;
+    } else
+      ID->long_comp = false;
+
+    if (dbg)
+      printf("  ID: nx=%d, nz=%d, 1st=%d, 2nd=%d\n", nx, nz, ID->firstorder,
+             ID->secondorder);
+  }
+
   if ((curr_elem.passMethod == "DriftPass")
-      || (curr_elem.passMethod == "CorrectorPass")
-      || (curr_elem.passMethod == "StrMPoleSymplectic4Pass")
-      || (curr_elem.passMethod == "BndMPoleSymplectic4RadPass")) {
+  || (curr_elem.passMethod == "CorrectorPass")
+  || (curr_elem.passMethod == "StrMPoleSymplectic4Pass")
+  || (curr_elem.passMethod == "BndMPoleSymplectic4RadPass")) {
     // Misalignment.
   }
 
   if (globval.Cell_nLoc == 0)
-      cell.S = 0e0;
-    else
+    cell.S = 0e0;
+  else
       cell.S = Cell[globval.Cell_nLoc-1].S + elem.PL;
 }
 
@@ -411,7 +555,15 @@ void rdmfile_at(const std::string& file_name) {
     // Otherwise it must be a property line.
     require_cur("Property", lineNo);
 
-    auto kv = parse_property_line(t);
+    // Catch parameter lines comming from 2d properites in AT
+    std::pair<std::string, std::vector<Value>> kv;
+    if (starts_with(t, "xtable,") || starts_with(t, "ytable,") ||
+        starts_with(t, "xkick,") || starts_with(t, "ykick,") ||
+        starts_with(t, "xkick1,") || starts_with(t, "ykick1,") ||
+        starts_with(t, "B2,"))
+      kv = parse_table_line(t);
+    else
+      kv = parse_property_line(t);
     auto& dst = cur.props[kv.first];
     dst.insert(dst.end(), kv.second.begin(), kv.second.end());
   }


### PR DESCRIPTION
## Summary

Implemented parsing of Insertion Device elements from AT flatExport. Handles both IdTablePass and IdTableRadPass.
New function `parse_table_line(std::string line)` to parse property lines coming from 2d properites in AT.

## Tested with Balder kickmap
### This method, with `rdmfile_at`

Test use case:
```cpp
#define NO 1
#include "tracy_lib.h"
int no_tps = NO;

void set_state(void) {
  globval.H_exact = false;
  globval.quad_fringe = false;
  globval.Cavity_on = false;
  globval.radiation = false;
  globval.emittance = false;
  globval.IBS = false;
  globval.pathlength = false;
  globval.Aperture_on = false;
  globval.Cart_Bend = false;
  globval.dip_edge_fudge = true;
}

int main(int argc, char *argv[]) {
  double eps_x, sigma_delta, U_0, J[3], tau[3], I[6];
  long int lastpos;
  ss_vect<double> ps;
  ss_vect<tps> M;

  ps[x_]     =  1e-4;
  ps[px_]    =  2e-4;
  ps[y_]     =  3e-4;
  ps[py_]    =  4e-4;
  ps[delta_] =  0e-4;
  ps[ct_]    =  6e-4;

  M.identity();
  reverse_elem = false;
  globval.mat_meth = false;
  trace = false;
  traceID = false;
  rdmfile_at(argv[1]);
  printf("Lattice file read from %s\n", argv[1]);
  set_state();
  globval.radiation = true;

  printf("Calculating single element pass...\n");
  cout << scientific << setprecision(7) << setw(15) << ps << "\n";
  Elem_Pass(0, ps);
  Cell_Pass(0, 1, M, lastpos);
  cout << scientific << setprecision(7) << setw(15) << ps << "\n";
  prt_lin_map(3, M);

  assert(false);
}
```
with output
```
initializing TPSA library: no = 1, nv = 6, eps = 1.000000e-25

rdmfile_at: read 1 elements, C = 0.00000
Lattice file read from BalderB2.dat
Calculating single element pass...
  1.0000000e-04  2.0000000e-04  3.0000000e-04  4.0000000e-04  0.0000000e+00  6.0000000e-04
  4.7988498e-04  1.9987601e-04  1.0353734e-03  3.7407177e-04 -1.4595438e-05  6.0018045e-04

cst
  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00 -1.444452e-05  0.000000e+00
map
  9.999140e-01  1.899918e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00
 -9.050635e-05  9.998996e-01  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00
  0.000000e+00  0.000000e+00  9.639952e-01  1.865795e+00  0.000000e+00  0.000000e+00
  0.000000e+00  0.000000e+00 -3.789926e-02  9.639813e-01  0.000000e+00  0.000000e+00
 -1.518291e-07 -1.442376e-07  3.977921e-05  3.779025e-05  9.999711e-01  0.000000e+00
  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00  1.000000e+00
```
### In AT and comparing:
- Single particle tracking:
```matlab
>> linepass(balderLine,[1e-4 2e-4 3e-4 4e-4 0 6e-4]')' - [4.7988498e-04  1.9987601e-04  1.0353734e-03  3.7407177e-04 -1.4595438e-05  6.0018045e-04]

ans =

      1.19811978263953e-12     -6.72180410291046e-14      6.85500981282769e-10      7.54300045872642e-10     -1.61943681813377e-09      -4.1859315492998e-12

>> -1.4595438e-05*3e9/1e3

ans =

                -43.786314
```
Energy lost matches the result from previous benchmark: 43 keV

- Comparison of linear map
```matlab
>> ATmap = linearMapFromTracking(Balder,[0 0 0 0 0 0]')

ATmap =

         0.999914020206352          1.89991831919603                         0                         0                         0                         0
     -9.05037384980164e-05         0.999899575319894                         0                         0                         0                         0
                         0                         0         0.963996227041875          1.86579641568978                         0                         0
                         0                         0       -0.0378981608858594         0.963982300992179                         0                         0
     -1.51845929493438e-07     -1.44246410877045e-07     -3.97836339457151e-05      -3.7794445548314e-05         0.999971107728777                         0
      3.89080258726236e-15      9.49918322707483e-07      6.82248245905391e-10      9.16412144731711e-07                         0                         1

>> ATmap-tracymap

ans =

      2.02063517029671e-08       3.1919603404873e-07                         0                         0                         0                         0
      2.61150198364315e-09     -2.46801060699298e-08                         0                         0                         0                         0
                         0                         0      1.02704187454616e-06      1.41568978073714e-06                         0                         0
                         0                         0      1.09911414060415e-06      1.00099217859029e-06                         0                         0
     -1.68294934382306e-11     -8.81087704484255e-12     -7.95628439457151e-05      -7.5584695548314e-05      7.72877706278763e-09                         0
      3.89080258726236e-15      9.49918322707483e-07      6.82248245905391e-10      9.16412144731711e-07                         0                         0
```